### PR TITLE
Add info about docker.for.mac.host.internal to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Similarly inspect logs for schema-registry and kafka-rest
 * Add a mapping with your machine ip to  `docker.for.mac.host.internal` to your `/etc/hosts` file
   * e.g. `10.0.4.162      docker.for.mac.host.internal`
   * find your machine ip with `ifconfig | grep -e "inet "`
+  * (!) your machine ip changes if you change network, update the config and restart the container
 * Connect to the kafka cluster via `localhost:29092` (bootstrap server)
 
 ### Publishing and Subscribing using Kafka REST

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Similarly inspect logs for schema-registry and kafka-rest
 
 ### Consuming and Producing using the Kafka clients
 * Add a mapping with your machine ip to  `docker.for.mac.host.internal` to your `/etc/hosts` file
-** e.g. `10.0.4.162      docker.for.mac.host.internal`
-** find your machine ip with `ifconfig | grep -e "inet "`
+  * e.g. `10.0.4.162      docker.for.mac.host.internal`
+  * find your machine ip with `ifconfig | grep -e "inet "`
 * Connect to the kafka cluster via `localhost:29092` (bootstrap server)
 
 ### Publishing and Subscribing using Kafka REST

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Similarly inspect logs for schema-registry and kafka-rest
 
 `docker-compose logs kafka-rest`
 
+### Consuming and Producing using the Kafka clients
+* Add a mapping with your machine ip to  `docker.for.mac.host.internal` to your `/etc/hosts` file
+** e.g. `10.0.4.162      docker.for.mac.host.internal`
+** find your machine ip with `ifconfig | grep -e "inet "`
+* Connect to the kafka cluster via `localhost:29092` (bootstrap server)
+
 ### Publishing and Subscribing using Kafka REST
 
 [confluentinc/kafka-rest](https://github.com/confluentinc/kafka-rest) has full documentation around this, but the validate.sh script allows you to run all the same quickly, go ahead and run it


### PR DESCRIPTION
I had to add `docker.for.mac.host.internal` as a hostname to my /etc/hosts file. I added this to the docs.