### PR TITLE
Configure transaction state for single nodes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://docker.for.mac.host.internal:29092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
     extra_hosts:
       - "moby:127.0.0.1"
       - "localhost: 127.0.0.1"


### PR DESCRIPTION
To use the EOS functionality, Kafka requires at least 2 brokers to be available by default. By changing those 2 settings (transaction.state.log.replication.factor and transaction.state.log.min.isr), it is possible to test transactional applications on a single node cluster. 

These settings are *not* recommended for production use.
